### PR TITLE
adding amazon linux support for systemd names

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -20,6 +20,15 @@ include_recipe 'openvpn::install'
 
 # systemd platforms use an instance service
 case node['platform_family']
+when 'amazon'
+  if node['platform_version'] >= '2'
+    link "/etc/systemd/system/multi-user.target.wants/openvpn@#{node['openvpn']['type']}.service" do
+      to '/usr/lib/systemd/system/openvpn@.service'
+    end
+    service_name = "openvpn@#{node['openvpn']['type']}.service"
+  else
+    service_name = 'openvpn'
+  end
 when 'rhel'
   if node['platform_version'] >= '7'
     link "/etc/systemd/system/multi-user.target.wants/openvpn@#{node['openvpn']['type']}.service" do


### PR DESCRIPTION
### Description

Enables systemd service names to work with Amazon Linux

### Issues Resolved

Enables systemd service names to work with Amazon Linux
### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
